### PR TITLE
Verbose flag hotfix

### DIFF
--- a/src/main/kotlin/orion/Main.kt
+++ b/src/main/kotlin/orion/Main.kt
@@ -710,7 +710,7 @@ fun loadOpenCVNativeLibrary() {
 
         try {
             // Download the JAR file
-            val connection = java.net.URL(mavenUrl).openConnection()
+            val connection = java.net.URI(mavenUrl).toURL().openConnection()
             connection.connect()
             val inputStream = connection.getInputStream()
             val outputStream = jarFile.outputStream()

--- a/src/main/kotlin/orion/Main.kt
+++ b/src/main/kotlin/orion/Main.kt
@@ -180,8 +180,10 @@ fun main(args: Array<String>) {
             actionConfigs = emptyMap()
         ))
 
-        // Set template matching verbosity using helper function
-        applyVerboseFlag(bot, useVerbose)
+        // Set template matching verbosity if --verbose flag is detected
+        if (useVerbose) {
+            bot.templateMatchingVerbosity = true
+        }
 
         bot.initialize()
 


### PR DESCRIPTION
This PR hotfix addresses two issues: ensuring that the verbose flag properly updates the bot’s template matching verbosity and improving the URL connection handling for downloading a JAR file.